### PR TITLE
INTPYTHON-743 Configure DATABASES with connection string in HOST

### DIFF
--- a/project_name/settings.py-tpl
+++ b/project_name/settings.py-tpl
@@ -10,8 +10,6 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/{{ docs_version }}/ref/settings/
 """
 
-import django_mongodb_backend
-
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -75,7 +73,11 @@ WSGI_APPLICATION = '{{ project_name }}.wsgi.application'
 # https://docs.djangoproject.com/en/{{ docs_version }}/ref/settings/#databases
 
 DATABASES = {
-    "default": django_mongodb_backend.parse_uri("mongodb://localhost:27017/{{ project_name }}"),
+    'default': {
+        'ENGINE': 'django_mongodb_backend',
+        'HOST': 'mongodb://localhost:27017/',
+        'NAME': '{{ project_name }}',
+    },
 }
 
 # Database routers


### PR DESCRIPTION
Probably the merge of this should be coordinated with the documentation update of the [tutorial](https://www.mongodb.com/docs/languages/python/django-mongodb/current/get-started/connect-mongodb/) (among other places). [edit: it's done]