### PR TITLE
Add 'django_mongodb_backend' to INSTALLED_APPS

### DIFF
--- a/project_name/settings.py-tpl
+++ b/project_name/settings.py-tpl
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django_mongodb_backend',
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
It's required for management command detection and template loading, which may or may not be used, but it doesn't hurt.